### PR TITLE
Updated action runner_type to python-script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+# 0.3.0
+
+- Updated action `runner_type` from `run-python` to `python-script`
+
 # 0.2.0
 
 - Rename `config.yaml` to `config.schema.yaml` and update to use schema.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ to `/opt/stackstorm/configs/jmx.yaml` and edit as required.
 You can also use dynamic values from the datastore. See the
 [docs](https://docs.stackstorm.com/reference/pack_configs.html) for more info.
 
+**Note** : When modifying the configuration in `/opt/stackstorm/configs/` please
+           remember to tell StackStorm to load these new values by running
+           `st2ctl reload --register-configs`
+
 ## Requirements (for running)
 
 * Java JRE >= 1.5

--- a/actions/invoke_method.yaml
+++ b/actions/invoke_method.yaml
@@ -1,6 +1,6 @@
 ---
   name: "invoke_method"
-  runner_type: "run-python"
+  runner_type: "python-script"
   description: "Invoke a provided MBean method exposed over JMX."
   enabled: true
   entry_point: "invoke_method.py"

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,6 +7,6 @@ keywords:
   - javajmx
   - java management extensions
   - mbean
-version: 0.2.0
+version: 0.3.0
 author: StackStorm, Inc.
 email: info@stackstorm.com


### PR DESCRIPTION
Updated action `runner_type` from `run-python` to `python-script` based on the following issue: https://github.com/StackStorm/st2/issues/3389 .

Also, updated README.md with a note on running `st2ctl reload --register-configs` when performing config modifications.